### PR TITLE
Scope PR CI workflow to catalog changes only

### DIFF
--- a/.github/workflows/build-verify-on-PR.yml
+++ b/.github/workflows/build-verify-on-PR.yml
@@ -2,8 +2,10 @@ name: CI
 
 on:
   pull_request:
-    branches: 
+    branches:
     - '**'
+    paths:
+    - 'catalog/**'
 
 jobs:
   build:


### PR DESCRIPTION
## Summary
- Adds a `paths: ['catalog/**']` filter to the PR validation workflow
- Prevents the Validate Contributor and Validate Contribution steps from running on PRs that don't touch catalog content (e.g., dependabot action version bumps)
- Fixes CI failures on PRs like #20 where the workflow is irrelevant

## Test plan
- [ ] Verify PRs touching only non-catalog files (e.g., `.github/workflows/`) no longer trigger the CI workflow
- [ ] Verify PRs touching files under `catalog/` still trigger validation as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)