### PR TITLE
CI: pass through on non-catalog PRs

### DIFF
--- a/.github/workflows/build-verify-on-PR.yml
+++ b/.github/workflows/build-verify-on-PR.yml
@@ -4,17 +4,33 @@ on:
   pull_request:
     branches:
     - '**'
-    paths:
-    - 'catalog/**'
 
 jobs:
-  build:
+  check-changes:
     runs-on: ubuntu-latest
-    
+    outputs:
+      catalog_changed: ${{ steps.filter.outputs.catalog }}
     steps:
       - name: Check out
         uses: actions/checkout@v2
-  
+
+      - name: Check for catalog changes
+        uses: dorny/paths-filter@v3
+        id: filter
+        with:
+          filters: |
+            catalog:
+              - 'catalog/**'
+
+  build:
+    needs: check-changes
+    if: needs.check-changes.outputs.catalog_changed == 'true'
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check out
+        uses: actions/checkout@v2
+
       # models a future action where the submittor is validated against auth access for the
       # catalog contribution
       - name: Validate Contributor
@@ -37,4 +53,3 @@ jobs:
           token: ${{ secrets.GH_PAT }}
           pull-request-number: ${{ github.event.pull_request.number }}
           merge-method: merge
-


### PR DESCRIPTION
## Summary
- Replaces the `paths` filter on the PR CI workflow with runtime change detection using `dorny/paths-filter@v3`
- Non-catalog PRs now get a passing CI status (skipped build job) instead of no status at all
- Catalog PRs continue to run full validation as before

Fixes the issue where PRs like #16 (dependabot workflow bumps) show no CI checks because the path filter prevented the workflow from triggering.

## Test plan
- [ ] Open a PR that only touches non-catalog files — CI should trigger and pass (build job skipped)
- [ ] Open a PR that touches `catalog/**` — CI should run full validation as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)